### PR TITLE
Add two features: "Open New Window Here" and "Reopen Here"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,17 +37,35 @@
             {
                 "command": "extension.scopeToHere",
                 "title": "Reopen Workbench Here"
+            },
+            {
+                "command": "extension.openNewWinHere",
+                "title": "Open New Window Here",
+                "category": "Files"
+            },
+            {
+                "command": "extension.reopenHere",
+                "title": "Reopen Here",
+                "category": "Files"
             }
         ],
         "menus": {
             "explorer/context": [
                 {
-                    "command": "extension.openNewInstance"
-                    ,"group": "navigation@1"
+                    "command": "extension.openNewInstance",
+                    "group": "navigation@1"
                 },
                 {
-                    "command": "extension.scopeToHere"
-                    ,"group": "navigation@1"
+                    "command": "extension.scopeToHere",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "extension.openNewWinHere",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "extension.reopenHere",
+                    "group": "navigation@1"
                 }
             ]
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,9 +40,10 @@ function openCommand(newWin) {
                 return;
             }
             file = path.resolve(file);
-            while (file !== "/" && files.length < 10) {
-                files.push(file);
+            files.push(file);
+            while (file !== "/" && files.length <= 10) {
                 file = path.dirname(file);
+                files.push(file);
             }
             vscode.window.showQuickPick(
                 files

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import * as path from 'path';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -19,11 +20,43 @@ export function activate(context: vscode.ExtensionContext) {
     let cmd2 = vscode.commands.registerCommand('extension.scopeToHere', (e: vscode.Uri) => {
         vscode.commands.executeCommand("vscode.openFolder", e, false);
     });
+    let newWin = vscode.commands.registerCommand('extension.openNewWinHere', openCommand(true));
+    let reopen = vscode.commands.registerCommand('extension.reopenHere', openCommand(false));
+    context.subscriptions.push(newWin);
+    context.subscriptions.push(reopen);
 
     context.subscriptions.push(cmd1);
     context.subscriptions.push(cmd2);
 }
 
+function openCommand(newWin) {
+    return function (e) {
+        try {
+            var files = [],
+                file = e ? e.path :
+                    (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.fileName);
+            if (!file) {
+                vscode.window.showErrorMessage("No file selected, and there is no active document.");
+                return;
+            }
+            file = path.resolve(file);
+            while (file !== "/" && files.length < 10) {
+                files.push(file);
+                file = path.dirname(file);
+            }
+            vscode.window.showQuickPick(
+                files
+                , { placeHolder: "" }).then(item => {
+                    if (!item) return;
+                    vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.parse(item), newWin);
+                }, err => {
+                    console.error(err);
+                });
+        } catch (ex) {
+            console.error(ex);
+        }
+    }
+}
 // this method is called when your extension is deactivated
 export function deactivate() {
 


### PR DESCRIPTION
I found this extension very useful, but sometimes I want to open the parent paths of the current file. 

In this PR, there are two new commands: "Open New Window Here" and "Reopen Here". They work much alike with the originals, except that they open a QuickPick list from which we can open the parent folders. The two new features already cover the original functions, which you might want to remove in the future.
![open here](https://cloud.githubusercontent.com/assets/668404/19556101/25b0b378-96f2-11e6-9375-17197a7c6f0a.png)
